### PR TITLE
commands/hitboxes.rs: minor improvements

### DIFF
--- a/src/commands/hitboxes.rs
+++ b/src/commands/hitboxes.rs
@@ -39,18 +39,19 @@ pub async fn hitboxes(
 
     let mut vec_embeds = Vec::new();
 
-    let mut embed_title = "__**".to_owned()
-        + &character.replace("_", " ") + " "
-        + &move_data.input + " / "
-        + &move_data.name + "**__";
+    let mut embed_title = "__**".to_owned() + &character.replace("_", " ") + " " + &move_data.input;
+    let mut embed_url = "https://dustloop.com/w/GGST/".to_owned() + &character.replace(" ", "_") + "#";
 
-    if move_data.input == move_data.name {
-        embed_title = "__**".to_owned()
-            + &character.replace('_', " ") + " "
-            + &move_data.input + "**__";
+    // check if the move has an actual name
+    if move_data.input != move_data.name && !move_data.name.trim().is_empty() {
+        embed_title += " / ";
+        embed_title += &move_data.name;
+        embed_url += &move_data.name.replace(" ", "_");
+    } else {
+        embed_url += &move_data.input;
     }
 
-    let embed_url = "https://dustloop.com/w/GGST/".to_owned() + &character.replace(" ", "_") + "#Overview";
+    embed_title += "**__";
 
     match hitbox_data.len() {
         // One hitbox image
@@ -92,20 +93,14 @@ pub async fn hitboxes(
         }
     };
 
-    if hitbox_data[0].hitbox_caption.is_empty() {
-        let mut reply = poise::CreateReply::default();
-        reply.embeds.extend(vec_embeds);
-
-        ctx.send(reply).await?;
-    }
-    else {
+    if !hitbox_data[0].hitbox_caption.trim().is_empty() {
         vec_embeds.push(CreateEmbed::new().color(EMBED_COLOR).description(&hitbox_data[0].hitbox_caption));
-        let mut reply = poise::CreateReply::default();
-        reply.embeds.extend(vec_embeds);
-
-        ctx.send(reply).await?;
     }
 
+    let mut reply = poise::CreateReply::default();
+    reply.embeds.extend(vec_embeds);
+
+    ctx.send(reply).await?;
 
     Ok(())
 }

--- a/src/commands/hitboxes.rs
+++ b/src/commands/hitboxes.rs
@@ -39,19 +39,19 @@ pub async fn hitboxes(
 
     let mut vec_embeds = Vec::new();
 
-    let mut embed_title = "__**".to_owned() + &character.replace("_", " ") + " " + &move_data.input;
-    let mut embed_url = "https://dustloop.com/w/GGST/".to_owned() + &character.replace(" ", "_") + "#";
+    let mut embed_title = "__**".to_owned()
+        + &character.replace("_", " ") + " "
+        + &move_data.input;
 
     // check if the move has an actual name
     if move_data.input != move_data.name && !move_data.name.trim().is_empty() {
         embed_title += " / ";
         embed_title += &move_data.name;
-        embed_url += &move_data.name.replace(" ", "_");
-    } else {
-        embed_url += &move_data.input;
     }
 
     embed_title += "**__";
+
+    let embed_url = "https://dustloop.com/w/GGST/".to_owned() + &character.replace(" ", "_") + "#Overview";
 
     match hitbox_data.len() {
         // One hitbox image
@@ -94,7 +94,8 @@ pub async fn hitboxes(
     };
 
     if !hitbox_data[0].hitbox_caption.trim().is_empty() {
-        vec_embeds.push(CreateEmbed::new().color(EMBED_COLOR).description(&hitbox_data[0].hitbox_caption));
+        vec_embeds.push(CreateEmbed::new().color(EMBED_COLOR)
+            .description(&hitbox_data[0].hitbox_caption));
     }
 
     let mut reply = poise::CreateReply::default();


### PR DESCRIPTION
There is currently a small bug where a hitbox caption will be displayed with "\&#32;" if the move has no hitbox caption. I originally set out to fix this, but I also ended up rewriting some other stuff slightly, as well as making the embed link anchor to the move instead of just #Overview.